### PR TITLE
Fix timeline visibility and improve date picker UX

### DIFF
--- a/sweem-tui/src/app.rs
+++ b/sweem-tui/src/app.rs
@@ -385,17 +385,17 @@ impl FormState {
         self.dropdown_open = false;
     }
 
-    /// Get mutable reference to the current text field
+    /// Get mutable reference to the current text field (not date pickers or selectors)
     pub fn current_text_mut(&mut self) -> Option<&mut String> {
         match self.current_field() {
             FormField::ClientName => Some(&mut self.client_name),
             FormField::ClientAddress => Some(&mut self.client_address),
             FormField::ProjectName => Some(&mut self.project_name),
-            FormField::ProjectStartDate => Some(&mut self.project_start_date),
-            FormField::ProjectEndDate => Some(&mut self.project_end_date),
             FormField::UserName => Some(&mut self.user_name),
             FormField::UserLogin => Some(&mut self.user_login),
             FormField::UserPassword => Some(&mut self.user_password),
+            // Date picker fields - use arrow keys instead of text input
+            FormField::ProjectStartDate | FormField::ProjectEndDate => None,
             _ => None,
         }
     }
@@ -1356,12 +1356,9 @@ impl App {
             return;
         }
 
-        // Get the project to center on (selected or first)
-        let idx = self.timeline_state.selected_project.unwrap_or(0);
-        if let Some(project) = self.projects.get(idx) {
-            let viewport_width = 100u16;
-            self.timeline_state.jump_to_project(project, &self.projects, viewport_width);
-        }
+        // Reset scroll to beginning so projects are immediately visible
+        // The timeline calculates start from the earliest project, so scroll 0 = first project visible
+        self.timeline_state.scroll_offset = 0;
     }
 
     /// Handle list view key events

--- a/sweem-tui/src/timeline.rs
+++ b/sweem-tui/src/timeline.rs
@@ -118,21 +118,18 @@ impl TimelineState {
     pub fn jump_to_project(&mut self, project: &ProjectDto, projects: &[ProjectDto], viewport_width: u16) {
         let timeline_start = self.calculate_timeline_start(projects);
 
-        // Calculate the middle of the project's duration
-        let project_end = project.actual_end_date.unwrap_or(project.planned_end_date);
-        let project_mid = project.start_date + Duration::days(
-            (project_end - project.start_date).num_days() / 2
-        );
+        // Calculate the start of the project (we want to see the project start, not the middle)
+        let project_start_days = (project.start_date - timeline_start).num_days();
 
-        // Calculate how many days from timeline start to project middle
-        let days_from_start = (project_mid - timeline_start).num_days();
-
-        // Center the viewport on this point
         // Account for the name column (about 24 chars) in the viewport
-        let effective_width = viewport_width.saturating_sub(24) as i64;
-        let center_offset = (effective_width / 2) * self.days_per_column as i64;
+        let effective_width = viewport_width.saturating_sub(26) as i64;
 
-        self.scroll_offset = (days_from_start - center_offset).max(0);
+        // Position the project start at about 1/4 from the left of the viewport
+        // This ensures the full project bar is visible
+        let offset_from_left = effective_width / 4;
+        let target_scroll = (project_start_days as f64 / self.days_per_column) as i64 - offset_from_left;
+
+        self.scroll_offset = target_scroll.max(0);
     }
 
     /// Calculate the start date of the timeline


### PR DESCRIPTION
## Summary
This PR addresses the remaining issues from #1 after the initial merge:

- **Fix timeline visibility**: Projects are now immediately visible when the Timeline tab is opened by resetting scroll offset to 0. This ensures the first project is visible without manual scrolling.

- **Improve date picker UX**: Date picker fields now only respond to arrow key navigation:
  - **Up/Down**: ±1 day
  - **Left/Right**: ±7 days (one week)
  - Text input is disabled for date fields to avoid confusion with the visual calendar
  - The mini calendar popup still appears when date fields are focused

- **Fix jump_to_project**: Improved positioning to show project start at 1/4 from the left edge of the viewport

## Test plan
- [ ] Projects appear immediately on timeline when data loads (no manual scrolling needed)
- [ ] Date picker fields don't accept typed characters
- [ ] Arrow keys work for date navigation (Up/Down: ±1 day, Left/Right: ±7 days)
- [ ] Visual calendar popup appears when date field is focused
- [ ] Text fields (Name, Login, Password, Address) still accept typed characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Follow-up to serial-experiments-ozon/trash1000#2