### PR TITLE
Fix timeline scroll_offset unit mismatch bug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/serial-experiments-ozon/trash1000/issues/6
+Your prepared branch: issue-6-d123691020e1
+Your prepared working directory: /tmp/gh-issue-solver-1766493177151
+Your forked repository: konard/serial-experiments-ozon-trash1000
+Original repository (upstream): serial-experiments-ozon/trash1000
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/serial-experiments-ozon/trash1000/issues/6
-Your prepared branch: issue-6-d123691020e1
-Your prepared working directory: /tmp/gh-issue-solver-1766493177151
-Your forked repository: konard/serial-experiments-ozon-trash1000
-Original repository (upstream): serial-experiments-ozon/trash1000
-
-Proceed.

--- a/experiments/timeline_debug.rs
+++ b/experiments/timeline_debug.rs
@@ -1,0 +1,50 @@
+/// Debug script to demonstrate the timeline unit mismatch bug fix
+///
+/// ## The Bug (Fixed)
+///
+/// In the original `jump_to_project` function, there was a unit mismatch:
+///
+/// ```rust
+/// // BUGGY CODE:
+/// let target_scroll = (project_start_days as f64 / self.days_per_column) as i64 - offset_from_left;
+/// self.scroll_offset = target_scroll.max(0);
+/// ```
+///
+/// The problem:
+/// - `project_start_days` is in DAYS
+/// - `/ self.days_per_column` converts to COLUMNS
+/// - `offset_from_left` is in COLUMNS
+/// - So `target_scroll` is in COLUMNS
+///
+/// But `scroll_offset` is used in `date_to_column_raw` as DAYS:
+/// ```rust
+/// let days_with_offset = days_from_start - self.state.scroll_offset;  // scroll_offset should be DAYS
+/// (days_with_offset as f64 / self.state.days_per_column) as i64
+/// ```
+///
+/// ## The Fix
+///
+/// Convert the column-based offset back to days:
+/// ```rust
+/// // FIXED CODE:
+/// let offset_from_left_days = (effective_width / 4) as f64 * self.days_per_column;
+/// let target_scroll = project_start_days - offset_from_left_days as i64;
+/// self.scroll_offset = target_scroll.max(0);
+/// ```
+///
+/// This ensures scroll_offset is always in DAYS, consistent with how it's used
+/// in scrolling (scroll_left/scroll_right) and in date_to_column_raw.
+///
+/// ## Example calculation
+///
+/// - days_per_column = 1.0
+/// - viewport_width = 100
+/// - effective_width = 100 - 26 = 74 columns
+/// - offset_from_left = 74 / 4 = 18 columns
+/// - offset_from_left_days = 18 * 1.0 = 18 days
+/// - If project starts on timeline start (day 0), scroll = 0 - 18 = 0 (clamped from -18)
+/// - This puts the project start at column 0, making it visible!
+fn main() {
+    println!("This file documents the timeline unit mismatch bug fix.");
+    println!("See the file comments for details.");
+}

--- a/sweem-tui/src/timeline.rs
+++ b/sweem-tui/src/timeline.rs
@@ -125,24 +125,26 @@ impl TimelineState {
         let days_from_start = (today - start).num_days();
         // Account for name column width (~26 chars) in viewport calculation
         let effective_width = width.saturating_sub(26) as i64;
-        let center_offset = (effective_width / 2) * self.days_per_column as i64;
-        self.scroll_offset = (days_from_start - center_offset).max(0);
+        // center_offset is in columns, convert to days by multiplying by days_per_column
+        let center_offset_days = (effective_width / 2) as f64 * self.days_per_column;
+        self.scroll_offset = (days_from_start - center_offset_days as i64).max(0);
     }
 
     /// Jump to and center on a specific project
     pub fn jump_to_project(&mut self, project: &ProjectDto, projects: &[ProjectDto], viewport_width: u16) {
         let timeline_start = self.calculate_timeline_start(projects);
 
-        // Calculate the start of the project (we want to see the project start, not the middle)
+        // Calculate the start of the project in days from timeline start
         let project_start_days = (project.start_date - timeline_start).num_days();
 
-        // Account for the name column (about 24 chars) in the viewport
+        // Account for the name column (about 26 chars) in the viewport
         let effective_width = viewport_width.saturating_sub(26) as i64;
 
         // Position the project start at about 1/4 from the left of the viewport
         // This ensures the full project bar is visible
-        let offset_from_left = effective_width / 4;
-        let target_scroll = (project_start_days as f64 / self.days_per_column) as i64 - offset_from_left;
+        // offset_from_left is in columns, convert to days by multiplying by days_per_column
+        let offset_from_left_days = (effective_width / 4) as f64 * self.days_per_column;
+        let target_scroll = project_start_days - offset_from_left_days as i64;
 
         self.scroll_offset = target_scroll.max(0);
     }


### PR DESCRIPTION
## Summary
- Fixed timeline project bar rendering by correcting a unit mismatch bug
- The `jump_to_project` and `center_on_today` functions were calculating `scroll_offset` in COLUMNS, but `date_to_column_raw` expects it in DAYS
- This caused project bars to not render correctly because the scroll position was being interpreted incorrectly

## Root Cause Analysis
The bug was in two functions in `sweem-tui/src/timeline.rs`:

1. **`jump_to_project`** (line 145):
   ```rust
   // BUGGY CODE:
   let target_scroll = (project_start_days as f64 / self.days_per_column) as i64 - offset_from_left;
   ```
   - This converts `project_start_days` (DAYS) to COLUMNS
   - Then subtracts `offset_from_left` (COLUMNS)
   - Result is in COLUMNS, but assigned to `scroll_offset` which should be in DAYS

2. **`center_on_today`** (line 128):
   ```rust
   // BUGGY CODE:
   let center_offset = (effective_width / 2) * self.days_per_column as i64;
   ```
   - Used integer cast `days_per_column as i64` which loses precision for values < 1.0

## The Fix
Keep all `scroll_offset` calculations in DAYS for consistency:

```rust
// FIXED jump_to_project:
let offset_from_left_days = (effective_width / 4) as f64 * self.days_per_column;
let target_scroll = project_start_days - offset_from_left_days as i64;

// FIXED center_on_today:
let center_offset_days = (effective_width / 2) as f64 * self.days_per_column;
self.scroll_offset = (days_from_start - center_offset_days as i64).max(0);
```

## Test Plan
- [x] Build passes (`cargo build`)
- [x] All tests pass (`cargo test`)
- [ ] Manual verification: Project bars now render correctly on the timeline
- [ ] Manual verification: Scrolling with h/l keys works correctly
- [ ] Manual verification: Zoom in/out with +/- works correctly

## Fixes
Fixes serial-experiments-ozon/trash1000#6

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)